### PR TITLE
add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.gopath
 .idea
 paas-sqs-broker
+local.nix

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    go = pkgs.go;
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+in (with args; {
+
+  paasSqsBrokerEnv = (pkgs.stdenv.mkDerivation rec {
+    name = "paas-sqs-broker-env";
+    shortName = "sqsbrk";
+    buildInputs = with pkgs; [ gitFull cacert go ];
+
+    LD_LIBRARY_PATH = "${pkgs.stdenv.lib.makeLibraryPath buildInputs}";
+    LANG="en_GB.UTF-8";
+    GOPATH = (toString (./.)) + "/.gopath";
+    GOFLAGS = "-mod=vendor";
+
+    shellHook = ''
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
+
+      mkdir -p $GOPATH
+    '';
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,24 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will
+# call, applying first the args passed to the original default.nix and then `oldAttrs`, the
+# attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would
+# wish to be applied to mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily
+  # to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the
+    # upstream shellHook script
+    export PS1="⚡$PS1⚡"
+    # inject some whimsy into our session - note here we access a package which we don't
+    # actually end up explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}


### PR DESCRIPTION
Also sources a `local.nix` if present, calling it to allow users to make personal additions or modifications to the derivation attrset.

This behaves basically the same way as I set up in the DMP nix files, documented at https://alphagov.github.io/digitalmarketplace-manual/developing-the-digital-marketplace/nix.html#local-nix, and a `local.example.nix` is provided for reference.