### PR TITLE
housekeeping: clean up integration tests to speed up failure cases

### DIFF
--- a/testing/integration/broker/broker_suite_test.go
+++ b/testing/integration/broker/broker_suite_test.go
@@ -1,70 +1,98 @@
 package broker_test
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
-	"github.com/pivotal-cf/brokerapi/domain"
-
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
+	"github.com/pivotal-cf/brokerapi"
+
+	brokerbase "github.com/alphagov/paas-service-broker-base/broker"
+	brokertesting "github.com/alphagov/paas-service-broker-base/testing"
+	"github.com/alphagov/paas-sqs-broker/sqs"
 )
+
+var (
+	broker brokertesting.BrokerTester
+)
+
+var _ = BeforeSuite(func() {
+
+	// integration tests are slow by nature, globally set the timeout
+	SetDefaultEventuallyTimeout(10 * time.Minute)
+
+	file, err := os.Open("../../fixtures/config.json")
+	Expect(err).ToNot(HaveOccurred())
+	defer file.Close()
+
+	config, err := brokerbase.NewConfig(file)
+	Expect(err).ToNot(HaveOccurred())
+
+	sqsClientConfig, err := sqs.NewConfig(config.Provider)
+	Expect(err).ToNot(HaveOccurred())
+
+	// by default the integration tests run without a permission boundary so
+	// that there are no dependencies on setting up external IAM policies
+	// to run the test with a predefined permission boundary policy set the following environment variable:
+	//
+	// PERMISSIONS_BOUNDARY_ARN="arn:aws:iam::ACCOUNT-ID:policy/SQSBrokerUserPermissionsBoundary"
+	//
+	optionalPermissionsBoundary := os.Getenv("PERMISSIONS_BOUNDARY_ARN")
+	if optionalPermissionsBoundary != "" {
+		sqsClientConfig.PermissionsBoundary = optionalPermissionsBoundary
+	}
+
+	logger := lager.NewLogger("sqs-service-broker-test")
+	logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, config.API.LagerLogLevel))
+
+	sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(sqsClientConfig.AWSRegion)}))
+
+	sqsProvider := &sqs.Provider{
+		Client: struct {
+			*secretsmanager.SecretsManager
+			*cloudformation.CloudFormation
+		}{
+			SecretsManager: secretsmanager.New(sess),
+			CloudFormation: cloudformation.New(sess),
+		},
+		Environment:         sqsClientConfig.DeployEnvironment,
+		ResourcePrefix:      sqsClientConfig.ResourcePrefix,
+		PermissionsBoundary: sqsClientConfig.PermissionsBoundary,
+		Timeout:             sqsClientConfig.Timeout,
+		Logger:              logger,
+	}
+
+	serviceBroker, err := brokerbase.New(config, sqsProvider, logger)
+	Expect(err).ToNot(HaveOccurred())
+	brokerAPI := brokerbase.NewAPI(serviceBroker, logger, config)
+
+	broker = brokertesting.New(brokerapi.BrokerCredentials{
+		Username: "username",
+		Password: "password",
+	}, brokerAPI)
+})
+
+// DescribeIntegrationTest acts like Describe but only conditionally runs tests
+// based on if the ENABLE_INTEGRATION_TESTS enviironment variable is set.  This
+// results in tests showing up as "pending" rather than as "passed" (which can
+// be misleading when viewing the test output)
+func DescribeIntegrationTest(desc string, fn func()) (ok bool) {
+	if os.Getenv("ENABLE_INTEGRATION_TESTS") == "true" {
+		ok = Describe(desc, fn)
+	} else {
+		ok = PDescribe(desc, fn)
+	}
+	return ok
+}
 
 func TestBroker(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Broker Suite")
-}
-
-func HaveLastOperationState(expectedState domain.LastOperationState) types.GomegaMatcher {
-	return &haveLastOperationStateMatcher{
-		expectedState: expectedState,
-	}
-}
-
-type haveLastOperationStateMatcher struct {
-	expectedState domain.LastOperationState
-}
-
-func (matcher *haveLastOperationStateMatcher) state(actual interface{}) (domain.LastOperationState, error) {
-	res, ok := actual.(*httptest.ResponseRecorder)
-	if !ok {
-		return "", fmt.Errorf("HaveLastOperationState matcher expects an httptest.ResponseRecorder")
-	}
-	var ret struct {
-		State domain.LastOperationState `json:"state"`
-	}
-	_ = json.NewDecoder(res.Result().Body).Decode(&ret)
-	return ret.State, nil
-}
-
-func (matcher *haveLastOperationStateMatcher) Match(actual interface{}) (success bool, err error) {
-	actualState, err := matcher.state(actual)
-	if err != nil {
-		return false, err
-	}
-	return actualState == matcher.expectedState, nil
-}
-
-func (matcher *haveLastOperationStateMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto have last operation state of\n\t%#v", actual, matcher.expectedState)
-}
-
-func (matcher *haveLastOperationStateMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nnot to have last operation state of\n\t%#v", actual, matcher.expectedState)
-}
-
-func (matcher *haveLastOperationStateMatcher) MatchMayChangeInTheFuture(actual interface{}) bool {
-	actualState, err := matcher.state(actual)
-	if err != nil {
-		return false
-	}
-	switch actualState {
-	case domain.InProgress:
-		return true
-	default:
-		return false
-	}
 }

--- a/testing/matchers/be_success_state.go
+++ b/testing/matchers/be_success_state.go
@@ -1,0 +1,64 @@
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	"github.com/pivotal-cf/brokerapi/domain"
+)
+
+const MaxFailures = 2
+
+// BeSuccessState is a gomega custom matcher for checking that the result of
+// receiving from a `chan domain.LastOperationState` is a successful state. It
+// mostly works like the `Receive(Equal(state))` matcher, but with the addition
+// that it understands how to bail out early from terminal conditions, making
+// it useful for use in Eventually calls polling the state chan
+func BeSuccessState() types.GomegaMatcher {
+	return &haveLastOperationStateMatcher{
+		expectedState: domain.Succeeded,
+	}
+}
+
+type haveLastOperationStateMatcher struct {
+	expectedState   domain.LastOperationState
+	inTerminalState bool
+	failures        int
+}
+
+func (matcher *haveLastOperationStateMatcher) Match(actual interface{}) (success bool, err error) {
+	ch, ok := actual.(chan domain.LastOperationState)
+	if !ok {
+		return false, fmt.Errorf("HaveLastOperationState matcher expects an chan domain.LastOperationState")
+	}
+	select {
+	case actualState, ok := <-ch:
+		if !ok { // channel got closed, bail out
+			matcher.inTerminalState = true
+			return false, nil
+		} else if actualState == domain.Failed { // if we see multiple failures in a row bail out
+			matcher.failures++
+			if matcher.failures > MaxFailures {
+				matcher.inTerminalState = true
+				return false, nil
+			}
+		} else { // reset fail count as something good happened
+			matcher.failures = 0
+		}
+		return actualState == matcher.expectedState, nil
+	default:
+		return false, nil // nothing on channel, return immeditely
+	}
+}
+
+func (matcher *haveLastOperationStateMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto have last operation state of\n\t%#v", actual, matcher.expectedState)
+}
+
+func (matcher *haveLastOperationStateMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nnot to have last operation state of\n\t%#v", actual, matcher.expectedState)
+}
+
+func (matcher *haveLastOperationStateMatcher) MatchMayChangeInTheFuture(actual interface{}) bool {
+	return !matcher.inTerminalState
+}


### PR DESCRIPTION
## What

Refactoring the integration tests a bit to make them fail-fast and make them easier to read...

* improve the state polling logic so that it correctly bails out early on failure
* improve the readability of the state polling by moving the repeated timeouts to move central locations
* improve the readability of the tests as a whole by using func blocks for each By step
* keep all the test setup in the BeforeSuite rather than a custom initalize function (we only ever need to setup the broker once)
* avoid the misleading "pass" when integration tests are disabled by marking the tests as "pending" when env var not instead.

the main technical change here is a switch to using channels for fetching the last-operation-state(s):

due to [a quirk in gomega's `Eventually` implementation](https://github.com/onsi/gomega/blob/1a3d249459a44387a05ca2d2c2b3d5f3db596dcb/internal/asyncassertion/async_assertion.go#L98), when you pass a function to poll to `Eventually` it ignores the Macther's MatchMayChangeInTheFuture result ... this led to the situation where polling must continue until the timeout is reached (10mins at least) even when we are in a terminal failed state where "no future change is possible"

to resolve this situation, channels are created for the state, and goroutines constantly poll last-operation in the background to fill the channels with the latest state. by using a channel we can then write a `MatchMayChangeInTheFuture` implementation for our custom matcher that actually works.

the new `BeSuccessState` matcher considers 3x failed states in a row to be unrecoverable, and will now bail out of tests after only 15seconds instead of 15min+ ... making failed integration test runs return their status significantly faster (especially useful for the github PR hook).

Some of these improvements might be better ported into broker-base, but for now the main aim was to avoid having to wait 15mins every time there is a test failure.

## How to review

* Probably view the full file and check that it reads nicely, the diff is likely hard to read since it mainly moves things around
* Tests still pass?
* Tests still doing what they should?

## Note

:information_source: this change does not require a new release, as it does not change any of the broker logic.
