### PR TITLE
Binding access policies

### DIFF
--- a/sqs/user_template.go
+++ b/sqs/user_template.go
@@ -43,7 +43,7 @@ type UserParams struct {
 	SecondaryQueueARN   string            `json:"-"`
 	Tags                map[string]string `json:"-"`
 	PermissionsBoundary string            `json:"-"`
-	AccessPolicy        AccessPolicy      `json:"-"`
+	AccessPolicy        AccessPolicy      `json:"access_policy"`
 }
 
 type Credentials struct {

--- a/sqs/user_template_test.go
+++ b/sqs/user_template_test.go
@@ -104,6 +104,71 @@ var _ = Describe("UserTemplate", func() {
 		})
 	})
 
+	Context("when the access policy is 'producer'", func() {
+		BeforeEach(func() {
+			params.AccessPolicy = "producer"
+		})
+		It("should use the 'producer' canned access policy", func() {
+			Expect(policy.PolicyDocument).To(BeAssignableToTypeOf(sqs.PolicyDocument{}))
+			policyDoc := policy.PolicyDocument.(sqs.PolicyDocument)
+			Expect(policyDoc.Statement[0].Action).To(ConsistOf(
+				"sqs:GetQueueAttributes",
+				"sqs:GetQueueUrl",
+				"sqs:ListDeadLetterSourceQueues",
+				"sqs:ListQueueTags",
+				"sqs:SendMessage",
+			))
+		})
+	})
+
+	Context("when the access policy is 'consumer'", func() {
+		BeforeEach(func() {
+			params.AccessPolicy = "consumer"
+		})
+		It("should use the 'consumer' canned access policy", func() {
+			Expect(policy.PolicyDocument).To(BeAssignableToTypeOf(sqs.PolicyDocument{}))
+			policyDoc := policy.PolicyDocument.(sqs.PolicyDocument)
+			Expect(policyDoc.Statement[0].Action).To(ConsistOf(
+				"sqs:DeleteMessage",
+				"sqs:GetQueueAttributes",
+				"sqs:GetQueueUrl",
+				"sqs:ListDeadLetterSourceQueues",
+				"sqs:ListQueueTags",
+				"sqs:PurgeQueue",
+				"sqs:ReceiveMessage",
+			))
+		})
+	})
+
+	Context("when the access policy is unspecified", func() {
+		BeforeEach(func() {
+			params.AccessPolicy = ""
+		})
+		It("should use the 'full' canned access policy", func() {
+			Expect(policy.PolicyDocument).To(BeAssignableToTypeOf(sqs.PolicyDocument{}))
+			policyDoc := policy.PolicyDocument.(sqs.PolicyDocument)
+			Expect(policyDoc.Statement[0].Action).To(ConsistOf(
+				"sqs:ChangeMessageVisibility",
+				"sqs:DeleteMessage",
+				"sqs:GetQueueAttributes",
+				"sqs:GetQueueUrl",
+				"sqs:ListDeadLetterSourceQueues",
+				"sqs:ListQueueTags",
+				"sqs:PurgeQueue",
+				"sqs:ReceiveMessage",
+				"sqs:SendMessage",
+			))
+		})
+	})
+
+	It("should return an error for unknown access policies", func() {
+		t, err := sqs.UserTemplate(sqs.UserParams{
+			AccessPolicy: "bananas",
+		})
+		Expect(t).To(BeNil())
+		Expect(err).To(MatchError("unknown access policy \"bananas\""))
+	})
+
 	Context("when queue ARNs are set", func() {
 		BeforeEach(func() {
 			params.PrimaryQueueARN = "abc"

--- a/sqs/user_template_test.go
+++ b/sqs/user_template_test.go
@@ -179,7 +179,7 @@ var _ = Describe("UserTemplate", func() {
 			policyDoc := policy.PolicyDocument.(sqs.PolicyDocument)
 			Expect(policyDoc.Statement).To(HaveLen(1))
 			Expect(policyDoc.Statement[0].Effect).To(Equal("Allow"))
-			Expect(policyDoc.Statement[0].Action).To(ContainElements(
+			Expect(policyDoc.Statement[0].Action).To(ConsistOf(
 				"sqs:ChangeMessageVisibility",
 				"sqs:DeleteMessage",
 				"sqs:GetQueueAttributes",


### PR DESCRIPTION
https://trello.com/c/5fF7jUFz

The implementation itself is straightforward as you can see, but the bits that get tricky* are around error handling. This seems to be the first time we're really expecting an error to be a real prospect and want error handling to be anything other than a 500 (?). And I only realized this when I came to write the tests for it.

The error cases we should expect to happen occasionally are:

 - bad json unmarshaling
 - unknown canned policy name

Both should result in a 400, but it's hard to know what the expected thing to do here is - how to extract enough information from the site of the error to:

 - Be able to decide this warrants a 400
 - Be able to give a vaguely useful error message

The easiest thing to do is produce a `NewFailureResponse` at the site of the error, which decides then and there that this should be a 400. But is that an abstraction violation? Thoughts please...

\* when I say "tricky", it's not _tricky_ tricky in any way, it's just Go lacking guidance