### PR TITLE
Add tests for Provision error handling, make error handling more accurate

### DIFF
--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -152,7 +152,7 @@ func (s *Provider) Bind(ctx context.Context, bindData provideriface.BindData) (*
 		SecondaryQueueURL: getStackOutput(queueStack, OutputSecondaryQueueURL),
 	}
 
-	if len(bindData.Details.RawParameters) > 0 {
+	if bindData.Details.RawParameters != nil {
 		decoder := json.NewDecoder(bytes.NewReader(bindData.Details.RawParameters))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&params); err != nil {

--- a/sqs/provider_test.go
+++ b/sqs/provider_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	goformation "github.com/awslabs/goformation/v4"
@@ -827,7 +826,10 @@ var _ = Describe("Provider", func() {
 			Context("when a nonexistent queue stack is specified", func() {
 				BeforeEach(func() {
 					fakeCfnClient.DescribeStacksWithContextReturnsOnCall(0, nil,
-						awserr.New("ResourceNotFoundException", "Nope couldn't find that", nil),
+						&fakeClient.MockAWSError{
+							C: "ValidationError",
+							M: "Something something does not exist something",
+						},
 					)
 				})
 				It("should return an appropriate error", func() {
@@ -840,6 +842,25 @@ var _ = Describe("Provider", func() {
 				})
 				It("should not have created a stack", func() {
 					Expect(fakeCfnClient.CreateStackWithContextCallCount()).To(BeZero())
+				})
+			})
+
+			Context("when the requested binding id already exists", func() {
+				BeforeEach(func() {
+					fakeCfnClient.CreateStackWithContextReturnsOnCall(0, nil,
+						&fakeClient.MockAWSError{
+							C: "AlreadyExistsException",
+							M: "Got one of those",
+						},
+					)
+				})
+				It("should return an appropriate error", func() {
+					Expect(errResponse).To(MatchError("binding already exists"))
+
+					Expect(errResponse).To(BeAssignableToTypeOf(&brokerapi.FailureResponse{}))
+					castErrResponse, ok := errResponse.(*brokerapi.FailureResponse)
+					Expect(ok).To(BeTrue())
+					Expect(castErrResponse.ValidatedStatusCode(nil)).To(Equal(409))
 				})
 			})
 		})


### PR DESCRIPTION
https://trello.com/c/ijecF1ie

Initially adding a test case for the `AlreadyExistsException`-handling I... slightly accidentally merged in my last PR (oops) and so that it looks like I meant to do this, add error-handling tests for the `Provision` method, making its error handling a bit more like `Bind`'s.

Still a little confused around whether to expect `DescribeStacks*` to return a `ValidationError` or a `ResourceNotFoundException`, I've changed my mock error responses to `ValidationError`s to match what other tests are doing.