### PR TITLE
add support for fifo queues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: test
 test:
-	go run github.com/onsi/ginkgo/ginkgo -v -mod=vendor ./...
+	go run github.com/onsi/ginkgo/ginkgo -v -mod=vendor -nodes=2 -stream ./...
 
 .PHONY: generate
 generate:

--- a/README.md
+++ b/README.md
@@ -135,8 +135,11 @@ To run integration tests against a real AWS environment you must have AWS
 credentials in your environment and you must set the ENABLE_INTEGRATION_TESTS
 environment variable to `true`.
 
+It may also be benefical to use the ginko test runner to enable parallel tests
+when working with the integration tests:
+
 ```
-ENABLE_INTEGRATION_TESTS=true go test -v ./...
+ENABLE_INTEGRATION_TESTS=true go run github.com/onsi/ginkgo/ginkgo -v -mod=vendor -nodes=2 -stream ./...
 ```
 
 If you have access to the GOV.UK PaaS build CI then you test with a permission boundary set using:

--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -50,9 +50,6 @@ type Provider struct {
 }
 
 func (s *Provider) Provision(ctx context.Context, provisionData provideriface.ProvisionData) (*domain.ProvisionedServiceSpec, error) {
-	if provisionData.Plan.Name == "fifo" {
-		return nil, apiresponses.NewFailureResponseBuilder(errors.New("FIFO plan unimplemented"), http.StatusNotImplemented, "not-implemented").WithEmptyResponse().Build()
-	}
 	queueTemplate := QueueTemplateBuilder{}
 	queueTemplate.QueueName = s.getStackName(provisionData.InstanceID)
 	queueTemplate.Tags = map[string]string{
@@ -60,6 +57,9 @@ func (s *Provider) Provision(ctx context.Context, provisionData provideriface.Pr
 		"Service":     "sqs",
 		"ServiceID":   provisionData.Details.ServiceID,
 		"Environment": s.Environment,
+	}
+	if provisionData.Plan.Name == "fifo" {
+		queueTemplate.FIFOQueue = true
 	}
 
 	tmpl, err := queueTemplate.Build()

--- a/sqs/provider_test.go
+++ b/sqs/provider_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Provider", func() {
 			})
 		})
 
-		XContext("FIFO queues", func() {
+		Context("FIFO queues", func() {
 			BeforeEach(func() {
 				provisionData = provideriface.ProvisionData{
 					InstanceID: "a5da1b66-da42-4c83-b806-f287bc589ab3",

--- a/sqs/queue_template_test.go
+++ b/sqs/queue_template_test.go
@@ -36,11 +36,11 @@ var _ = Describe("QueueTemplateBuilder", func() {
 		BeforeEach(func() {
 			builder.QueueName = "q-name-a"
 		})
-		It("should set primary queue name with a .stnd extension", func() {
+		It("should set primary queue name with suitable suffix", func() {
 			Expect(primaryQueue.QueueName).To(HavePrefix("q-name-a"))
 			Expect(primaryQueue.QueueName).To(HaveSuffix("-pri"))
 		})
-		It("should set secondary queue name with a .stnd extension", func() {
+		It("should set secondary queue name with suitable suffix", func() {
 			Expect(secondaryQueue.QueueName).To(HavePrefix("q-name-a"))
 			Expect(secondaryQueue.QueueName).To(HaveSuffix("-sec"))
 		})

--- a/sqs/queue_template_test.go
+++ b/sqs/queue_template_test.go
@@ -32,17 +32,40 @@ var _ = Describe("QueueTemplateBuilder", func() {
 		Expect(ok).To(BeTrue())
 	})
 
-	Context("when QueueName is set", func() {
+	Context("when QueueName is set for a non-FIFO queue", func() {
 		BeforeEach(func() {
 			builder.QueueName = "q-name-a"
 		})
-		It("should set primary queue name", func() {
+		It("should set primary queue name with a .stnd extension", func() {
 			Expect(primaryQueue.QueueName).To(HavePrefix("q-name-a"))
 			Expect(primaryQueue.QueueName).To(HaveSuffix("-pri"))
 		})
-		It("should set secondary queue name", func() {
+		It("should set secondary queue name with a .stnd extension", func() {
 			Expect(secondaryQueue.QueueName).To(HavePrefix("q-name-a"))
 			Expect(secondaryQueue.QueueName).To(HaveSuffix("-sec"))
+		})
+		It("should not break the 80 character limit for queue name", func() {
+			Expect(len(primaryQueue.QueueName)).To(BeNumerically("<", 80))
+			Expect(len(secondaryQueue.QueueName)).To(BeNumerically("<", 80))
+		})
+	})
+
+	Context("when QueueName is set for a FIFO queue", func() {
+		BeforeEach(func() {
+			builder.QueueName = "q-name-a"
+			builder.FIFOQueue = true
+		})
+		It("should set primary queue name with a .fifo extension", func() {
+			Expect(primaryQueue.QueueName).To(HavePrefix("q-name-a"))
+			Expect(primaryQueue.QueueName).To(HaveSuffix("-pri.fifo"))
+		})
+		It("should set secondary queue name with a .fifo extension", func() {
+			Expect(secondaryQueue.QueueName).To(HavePrefix("q-name-a"))
+			Expect(secondaryQueue.QueueName).To(HaveSuffix("-sec.fifo"))
+		})
+		It("should not break the 80 character limit for queue name", func() {
+			Expect(len(primaryQueue.QueueName)).To(BeNumerically("<", 80))
+			Expect(len(secondaryQueue.QueueName)).To(BeNumerically("<", 80))
 		})
 	})
 
@@ -108,9 +131,9 @@ var _ = Describe("QueueTemplateBuilder", func() {
 		Expect(secondaryQueue.FifoQueue).To(BeFalse())
 	})
 
-	XContext("when IsFIFO is set", func() {
+	Context("when FIFO queue is configured", func() {
 		BeforeEach(func() {
-			// builder.IsFIFO = true
+			builder.FIFOQueue = true
 		})
 		It("should set queue FifoQueue from spec", func() {
 			Expect(primaryQueue.FifoQueue).To(BeTrue())
@@ -119,7 +142,8 @@ var _ = Describe("QueueTemplateBuilder", func() {
 	})
 
 	It("should have outputs for connection details", func() {
-		text, err := sqs.QueueTemplateBuilder{}.Build()
+		builder := &sqs.QueueTemplateBuilder{}
+		text, err := builder.Build()
 		Expect(err).ToNot(HaveOccurred())
 		t, err := goformation.ParseYAML([]byte(text))
 		Expect(err).ToNot(HaveOccurred())

--- a/sqs/templates.go
+++ b/sqs/templates.go
@@ -73,7 +73,9 @@ Resources:
   PrimaryQueue:
     Properties:
       QueueName: {{.PrimaryQueueName}}
+{{ if .FIFOQueue }}
       FifoQueue: {{.FIFOQueue}}
+{{ end }}
       Tags:
       - Key: QueueType
         Value: Primary
@@ -98,7 +100,9 @@ Resources:
   SecondaryQueue:
     Properties:
       QueueName: {{.SecondaryQueueName}}
+{{ if .FIFOQueue }}
       FifoQueue: {{.FIFOQueue}}
+{{ end }}
       Tags:
       - Key: QueueType
         Value: Secondary

--- a/sqs/templates.go
+++ b/sqs/templates.go
@@ -112,28 +112,20 @@ Resources:
 Outputs:
   PrimaryQueueARN:
     Description: Primary queue ARN
-    Export:
-      Name: {{.QueueName}}-PrimaryQueueARN
     Value:
       Fn::GetAtt:
       - PrimaryQueue
       - Arn
   PrimaryQueueURL:
     Description: Primary queue URL
-    Export:
-      Name: {{.QueueName}}-PrimaryQueueURL
     Value: !Ref PrimaryQueue
   SecondaryQueueARN:
     Description: Secondary queue ARN
-    Export:
-      Name: {{.QueueName}}-SecondaryQueueARN
     Value:
       Fn::GetAtt:
       - SecondaryQueue
       - Arn
   SecondaryQueueURL:
     Description: Secondary queue URL
-    Export:
-      Name: {{.QueueName}}-SecondaryQueueURL
     Value: !Ref SecondaryQueue
 `

--- a/sqs/templates.go
+++ b/sqs/templates.go
@@ -72,7 +72,8 @@ Conditions:
 Resources:
   PrimaryQueue:
     Properties:
-      QueueName: {{.QueueName}}-pri
+      QueueName: {{.PrimaryQueueName}}
+      FifoQueue: {{.FIFOQueue}}
       Tags:
       - Key: QueueType
         Value: Primary
@@ -96,7 +97,8 @@ Resources:
     Type: AWS::SQS::Queue
   SecondaryQueue:
     Properties:
-      QueueName: {{.QueueName}}-sec
+      QueueName: {{.SecondaryQueueName}}
+      FifoQueue: {{.FIFOQueue}}
       Tags:
       - Key: QueueType
         Value: Secondary


### PR DESCRIPTION
updates the broker to correctly support and test fifo queues.

fifo queues have a strange requirement that the queue names must end with a ".fifo" suffix, since we did not explicitly test the fifo queue in the integration tests this went unnoticed.

the integration tests have been extended to now run two passes of the full lifecycle ... once for "standard" and once for "fifo" queues. Since fifo queues require a MessageGroupID/DeduplicationID set in the SendMessage calls we need to tweak the send payload per test as well as the provision params.

To support the weird "fifo" extension in names, queue names are now generated by functions and conform to the following pattern:

```
$PREFIX-$UUID-$KIND.$EXT
```

Where:

* `$PREFIX` is something like "paas-sqs-broker"
* `$UUID` is the service instance id
* `$KIND` is the primary/secondary marker
* `$EXT` is either `""` or `".fifo"` depending on the FIFO-ness

