### PR TITLE
Allow specifying an additional policy on managed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,32 @@ A policy must exist with at least these permissions:
 ```
 And this must match the name used in the iam:PermissionsBoundary condition above (SQSBrokerUserPermissionsBoundary in this example).
 
+Additionally, you may provide an additional IAM Policy that will be
+attached to all IAM Users managed by this broker.  For example, you
+could use the following policy to restrict access to a particular VPC:
+
+
+```json
+{
+   "Version": "2012-10-17",
+   "Id": "Policy1415115909153",
+   "Statement": [
+     {
+       "Sid": "Access-to-specific-VPC-only",
+       "Principal": "*",
+       "Action": "*",
+       "Effect": "Deny",
+       "Resource": "*",
+       "Condition": {
+         "StringNotEquals": {
+           "aws:SourceVpc": "vpc-111bbb22"
+         }
+       }
+     }
+   ]
+}
+```
+
 ### Configuration options
 
 The following options can be added to the configuration file:
@@ -120,7 +146,8 @@ The following options can be added to the configuration file:
 | `log_level`                      | debug         | string | debug,info,error,fatal                                                     |
 | `aws_region`                     | empty string  | string | any [AWS region](https://docs.aws.amazon.com/general/latest/gr/rande.html) |
 | `resource_prefix`                | empty string  | string | any                                                                        |
-| `permissions_boundary`                | empty string  | string | any                                                                        |
+| `additional_user_policy`         | empty string  | string | an ARN of an IAM Policy                                                    |
+| `permissions_boundary`           | empty string  | string | an ARN of an IAM Policy                                                    |
 | `deploy_env`                     | empty string  | string |                                                                            |
 
 ## Running tests

--- a/main.go
+++ b/main.go
@@ -63,11 +63,12 @@ func main() {
 			SecretsManager: secretsmanager.New(sess, cfg),
 			CloudFormation: cloudformation.New(sess, cfg),
 		},
-		Environment:         sqsClientConfig.DeployEnvironment,
-		ResourcePrefix:      sqsClientConfig.ResourcePrefix,
-		PermissionsBoundary: sqsClientConfig.PermissionsBoundary,
-		Timeout:             sqsClientConfig.Timeout,
-		Logger:              logger,
+		Environment:          sqsClientConfig.DeployEnvironment,
+		ResourcePrefix:       sqsClientConfig.ResourcePrefix,
+		AdditionalUserPolicy: sqsClientConfig.AdditionalUserPolicy,
+		PermissionsBoundary:  sqsClientConfig.PermissionsBoundary,
+		Timeout:              sqsClientConfig.Timeout,
+		Logger:               logger,
 	}
 
 	serviceBroker, err := broker.New(config, sqsProvider, logger)

--- a/sqs/client.go
+++ b/sqs/client.go
@@ -20,11 +20,17 @@ type Client interface {
 }
 
 type Config struct {
-	AWSRegion           string `json:"aws_region"`
-	ResourcePrefix      string `json:"resource_prefix"`
-	DeployEnvironment   string `json:"deploy_env"`
-	Timeout             time.Duration
-	PermissionsBoundary string `json:"permissions_boundary"`
+	AWSRegion         string `json:"aws_region"`
+	ResourcePrefix    string `json:"resource_prefix"`
+	DeployEnvironment string `json:"deploy_env"`
+	Timeout           time.Duration
+	// AdditionalUserPolicy is optionally the ARN of an IAM Policy that
+	// will be attached to each IAM User created by the broker.  The
+	// intended use case is, for example, to restrict all access to be
+	// from a particular VPC, source IP, or via a particular VPC
+	// Endpoint.
+	AdditionalUserPolicy string `json:"additional_user_policy"`
+	PermissionsBoundary  string `json:"permissions_boundary"`
 }
 
 func NewConfig(configJSON []byte) (*Config, error) {

--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -41,12 +41,13 @@ var (
 )
 
 type Provider struct {
-	Environment         string // Name of environment to tag resources with
-	Client              Client // AWS SDK compatible client
-	ResourcePrefix      string // AWS resources with be named with this prefix
-	PermissionsBoundary string // IAM users created on bind will have this boundary
-	Timeout             time.Duration
-	Logger              lager.Logger
+	Environment          string // Name of environment to tag resources with
+	Client               Client // AWS SDK compatible client
+	ResourcePrefix       string // AWS resources with be named with this prefix
+	AdditionalUserPolicy string // IAM users created on bind will have this policy attached
+	PermissionsBoundary  string // IAM users created on bind will have this boundary
+	Timeout              time.Duration
+	Logger               lager.Logger
 }
 
 func (s *Provider) Provision(ctx context.Context, provisionData provideriface.ProvisionData) (*domain.ProvisionedServiceSpec, error) {
@@ -146,9 +147,10 @@ func (s *Provider) Bind(ctx context.Context, bindData provideriface.BindData) (*
 	}
 
 	userTemplate := UserTemplateBuilder{
-		BindingID:           bindData.BindingID,
-		ResourcePrefix:      s.ResourcePrefix,
-		PermissionsBoundary: s.PermissionsBoundary,
+		BindingID:            bindData.BindingID,
+		ResourcePrefix:       s.ResourcePrefix,
+		AdditionalUserPolicy: s.AdditionalUserPolicy,
+		PermissionsBoundary:  s.PermissionsBoundary,
 		Tags: map[string]string{
 			"Name":        bindData.BindingID,
 			"Service":     "sqs",

--- a/sqs/provider_test.go
+++ b/sqs/provider_test.go
@@ -791,6 +791,10 @@ var _ = Describe("Provider", func() {
 				Expect(user.PermissionsBoundary).To(BeEmpty())
 			})
 
+			It("should not set additional policies by default", func() {
+				Expect(user.ManagedPolicyArns).To(BeEmpty())
+			})
+
 			It("should extract arns from queue stack outputs", func() {
 				Expect(policy.PolicyDocument).To(
 					HaveKeyWithValue("Statement", ContainElement(
@@ -805,6 +809,15 @@ var _ = Describe("Provider", func() {
 				})
 				It("should create user with a permission boundary if provided", func() {
 					Expect(user.PermissionsBoundary).To(Equal("arn:fake:permission:boundary"))
+				})
+			})
+
+			Context("when additional user policy is provided", func() {
+				BeforeEach(func() {
+					sqsProvider.AdditionalUserPolicy = "arn:fake:managed:policy"
+				})
+				It("should create user with a permission boundary if provided", func() {
+					Expect(user.ManagedPolicyArns).To(ConsistOf("arn:fake:managed:policy"))
 				})
 			})
 

--- a/sqs/templates.go
+++ b/sqs/templates.go
@@ -183,6 +183,10 @@ Resources:
 {{ if .PermissionsBoundary }}
       PermissionsBoundary: {{ .PermissionsBoundary }}
 {{ end }}
+{{ if .AdditionalUserPolicy }}
+      ManagedPolicyArns:
+      - "{{ .AdditionalUserPolicy }}"
+{{ end }}
       UserName: binding-{{ .BindingID }}
 {{ if .Tags }}
       Tags:

--- a/sqs/user_template.go
+++ b/sqs/user_template.go
@@ -30,17 +30,18 @@ const (
 )
 
 type UserTemplateBuilder struct {
-	BindingID           string            `json:"-"`
-	ResourcePrefix      string            `json:"-"`
-	UserPath            string            `json:"-"`
-	PrimaryQueueURL     string            `json:"-"`
-	PrimaryQueueARN     string            `json:"-"`
-	SecondaryQueueURL   string            `json:"-"`
-	SecondaryQueueARN   string            `json:"-"`
-	Tags                map[string]string `json:"-"`
-	PermissionsBoundary string            `json:"-"`
-	AccessPolicy        AccessPolicy      `json:"access_policy"`
-	AccessPolicyActions []string
+	BindingID            string            `json:"-"`
+	ResourcePrefix       string            `json:"-"`
+	UserPath             string            `json:"-"`
+	PrimaryQueueURL      string            `json:"-"`
+	PrimaryQueueARN      string            `json:"-"`
+	SecondaryQueueURL    string            `json:"-"`
+	SecondaryQueueARN    string            `json:"-"`
+	Tags                 map[string]string `json:"-"`
+	AdditionalUserPolicy string            `json:"-"`
+	PermissionsBoundary  string            `json:"-"`
+	AccessPolicy         AccessPolicy      `json:"access_policy"`
+	AccessPolicyActions  []string
 }
 
 type Credentials struct {

--- a/sqs/user_template_test.go
+++ b/sqs/user_template_test.go
@@ -164,6 +164,21 @@ var _ = Describe("UserTemplate", func() {
 		})
 	})
 
+	Context("when additional user policy is not set", func() {
+		It("should not set an additional policy", func() {
+			Expect(user.ManagedPolicyArns).To(BeEmpty())
+		})
+	})
+
+	Context("when additional user policy is set", func() {
+		BeforeEach(func() {
+			builder.AdditionalUserPolicy = "lololol"
+		})
+		It("should set an additional policy", func() {
+			Expect(user.ManagedPolicyArns).To(ConsistOf("lololol"))
+		})
+	})
+
 	It("should return an error for unknown access policies", func() {
 		t, err := sqs.UserTemplateBuilder{
 			AccessPolicy: "bananas",


### PR DESCRIPTION
We want to be able to restrict IAM Users managed by the SQS broker to
a particular domain (eg VPC, source IP, whatever).  This adds a
configuration item `additional_user_policy` which is the ARN of a
managed policy which will be attached to every managed IAM User.  This
enables setting a "local-only" policy that denies all requests without
the appropriate value of `aws:SourceVpc`.  See README update for
details.