### PR TITLE
support synchronous bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alphagov/paas-sqs-broker
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/alphagov/paas-service-broker-base v0.8.0
+	github.com/alphagov/paas-service-broker-base v0.9.0
 	github.com/aws/aws-sdk-go v1.34.20
 	github.com/awslabs/goformation/v4 v4.15.0
 	github.com/imdario/mergo v0.3.11 // indirect
@@ -14,6 +14,7 @@ require (
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect
 	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/alphagov/paas-sqs-broker
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/alphagov/paas-service-broker-base v0.9.0
+	github.com/alphagov/paas-service-broker-base v0.10.0
 	github.com/aws/aws-sdk-go v1.34.20
 	github.com/awslabs/goformation/v4 v4.15.0
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alphagov/paas-service-broker-base v0.8.0 h1:GRmFNW2B8EcBtpcm9xGLPFkXwcqCn06PQu9jtgZhYEU=
-github.com/alphagov/paas-service-broker-base v0.8.0/go.mod h1:EhyM8tqEv4OjtvJd/8i8Wor2NVs6x3JDBLi2xHcTB7k=
-github.com/alphagov/paas-service-broker-base v0.9.0 h1:euBSnF1oxBoSTpzyN9eXFsnHk/L3R7iA+HLaykVpcZM=
-github.com/alphagov/paas-service-broker-base v0.9.0/go.mod h1:EhyM8tqEv4OjtvJd/8i8Wor2NVs6x3JDBLi2xHcTB7k=
+github.com/alphagov/paas-service-broker-base v0.10.0 h1:v/IRpUhErmlNRzW0R2Iv/eLjDmavlXW5ufKkq+DLlC4=
+github.com/alphagov/paas-service-broker-base v0.10.0/go.mod h1:EhyM8tqEv4OjtvJd/8i8Wor2NVs6x3JDBLi2xHcTB7k=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -38,8 +36,6 @@ github.com/armon/go-metrics v0.3.4 h1:Xqf+7f2Vhl9tsqDYmXhnXInUdcrtgpRNpIA15/uldS
 github.com/armon/go-metrics v0.3.4/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.34.18 h1:Mo/Clq3u1dQFzpg8YQqBii8m+Vl3fWIfHi6kXs5wpuM=
-github.com/aws/aws-sdk-go v1.34.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.20 h1:D9otznteZZyN5pRyFETqveYia/85Xzk7+RaPGB1I9fE=
 github.com/aws/aws-sdk-go v1.34.20/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/awslabs/goformation/v4 v4.15.0 h1:yZM85dzEKrRIPpMZIdsUV+EWbvhWsfoqC81Fv/aFPck=
@@ -179,6 +175,7 @@ github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/joefitzgerald/rainbow-reporter v0.1.0 h1:AuMG652zjdzI0YCCnXAqATtRBpGXMcAnrajcaTrSeuo=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -301,6 +298,7 @@ github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522/go.mod h1:tQTYKOQgxo
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -400,8 +398,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200908134130-d2e65c121b96 h1:gJciq3lOg0eS9fSZJcoHfv7q1BfC6cJfnmSSKL1yu3Q=
-golang.org/x/sys v0.0.0-20200908134130-d2e65c121b96/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alphagov/paas-service-broker-base v0.8.0 h1:GRmFNW2B8EcBtpcm9xGLPFkXwcqCn06PQu9jtgZhYEU=
 github.com/alphagov/paas-service-broker-base v0.8.0/go.mod h1:EhyM8tqEv4OjtvJd/8i8Wor2NVs6x3JDBLi2xHcTB7k=
+github.com/alphagov/paas-service-broker-base v0.9.0 h1:euBSnF1oxBoSTpzyN9eXFsnHk/L3R7iA+HLaykVpcZM=
+github.com/alphagov/paas-service-broker-base v0.9.0/go.mod h1:EhyM8tqEv4OjtvJd/8i8Wor2NVs6x3JDBLi2xHcTB7k=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"time"
 
 	"fmt"
 	"net"
@@ -21,10 +20,6 @@ import (
 )
 
 var configFilePath string
-
-func init() {
-	broker.DefaultContextTimeout = 5 * time.Minute
-}
 
 func main() {
 	flag.StringVar(&configFilePath, "config", "", "Location of the config file")

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	"fmt"
 	"net"
@@ -20,6 +21,10 @@ import (
 )
 
 var configFilePath string
+
+func init() {
+	broker.DefaultContextTimeout = 5 * time.Minute
+}
 
 func main() {
 	flag.StringVar(&configFilePath, "config", "", "Location of the config file")

--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/alphagov/paas-service-broker-base/broker"
 	provideriface "github.com/alphagov/paas-service-broker-base/provider"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -20,10 +19,6 @@ import (
 	"github.com/pivotal-cf/brokerapi/domain"
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
 )
-
-func init() {
-	broker.DefaultContextTimeout = 5 * time.Minute
-}
 
 var (
 	// capabilities required by cloudformation

--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -35,7 +35,7 @@ var (
 	// ErrStackNotFound returned when stack does not exist, or has been deleted
 	ErrStackNotFound = fmt.Errorf("cloudformation stack does not exist")
 	// ErrBindingDeadlineExeceeded indicates that syncronous binding took too long
-	ErrBindingDeadlineExeceeded = fmt.Errorf("timeout waiting for the binding stack to reach a success or failed state")
+	ErrBindingDeadlineExceeded = fmt.Errorf("timeout waiting for the binding stack to reach a success or failed state")
 	// PollingInterval is the duration between calls to check state when waiting for stack status to complete
 	PollingInterval      = time.Second * 5
 	ProvisionOperation   = "provision"
@@ -247,7 +247,7 @@ func (s *Provider) waitForBindingOperationComplete(ctx context.Context, stackNam
 	for {
 		select {
 		case <-ctx.Done():
-			return ErrBindingDeadlineExeceeded
+			return ErrBindingDeadlineExceeded
 		case <-time.After(PollingInterval):
 			lastOperation, err := s.lastBindingOperation(ctx, stackName, BindOperation)
 			if err != nil {

--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/alphagov/paas-service-broker-base/broker"
 	provideriface "github.com/alphagov/paas-service-broker-base/provider"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -21,6 +21,10 @@ import (
 	"github.com/pivotal-cf/brokerapi/domain/apiresponses"
 )
 
+func init() {
+	broker.DefaultContextTimeout = 5 * time.Minute
+}
+
 var (
 	// capabilities required by cloudformation
 	capabilities = []*string{
@@ -29,10 +33,11 @@ var (
 	// NoExistErrMatch is a string to match if stack does not exist
 	NoExistErrMatch = "does not exist"
 	// ErrStackNotFound returned when stack does not exist, or has been deleted
-	ErrStackNotFound      = fmt.Errorf("cloudformation stack does not exist")
-	ErrUpdateNotSupported = errors.New("Updating the SQS queue is currently not supported")
-	// PollingInterval is the duration between calls to check state when waiting for apply/destroy to complete
-	PollingInterval      = time.Second * 15
+	ErrStackNotFound = fmt.Errorf("cloudformation stack does not exist")
+	// ErrBindingDeadlineExeceeded indicates that syncronous binding took too long
+	ErrBindingDeadlineExeceeded = fmt.Errorf("timeout waiting for the binding stack to reach a success or failed state")
+	// PollingInterval is the duration between calls to check state when waiting for stack status to complete
+	PollingInterval      = time.Second * 5
 	ProvisionOperation   = "provision"
 	DeprovisionOperation = "deprovision"
 	UpdateOperation      = "update"
@@ -180,10 +185,11 @@ func (s *Provider) Bind(ctx context.Context, bindData provideriface.BindData) (*
 		return nil, err
 	}
 
+	bindingStackName := s.getStackName(bindData.BindingID)
 	_, err = s.Client.CreateStackWithContext(ctx, &cloudformation.CreateStackInput{
 		Capabilities: capabilities,
 		TemplateBody: aws.String(tmpl),
-		StackName:    aws.String(s.getStackName(bindData.BindingID)),
+		StackName:    aws.String(bindingStackName),
 	})
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AlreadyExistsException" {
@@ -192,10 +198,71 @@ func (s *Provider) Bind(ctx context.Context, bindData provideriface.BindData) (*
 		return nil, err
 	}
 
+	if !bindData.AsyncAllowed {
+		return s.getBindingSync(ctx, bindingStackName)
+	}
+
 	return &domain.Binding{
 		IsAsync:       true,
 		OperationData: BindOperation,
 	}, nil
+}
+
+// getBindingSync will fetch the binding credentials for the given binding
+// cloudformation stack name. It will block until the stack reports it is
+// in either a success or failed state.
+func (s *Provider) getBindingSync(ctx context.Context, bindingStackName string) (*domain.Binding, error) {
+
+	// catch and attempt to tidy up failed binding stacks
+	destroyFailedBinding := true
+	defer func() {
+		if destroyFailedBinding {
+			go s.tryDestroyStack(bindingStackName)
+		}
+	}()
+
+	// wait for the stack to settle
+	err := s.waitForBindingOperationComplete(ctx, bindingStackName)
+	if err != nil {
+		return nil, err
+	}
+	// fetch the credentials
+	binding, err := s.getBinding(ctx, bindingStackName)
+	if err != nil {
+		return nil, err
+	}
+	// mark as valid to disable clean up
+	destroyFailedBinding = false
+
+	return &domain.Binding{
+		OperationData: BindOperation,
+		Credentials:   binding.Credentials,
+	}, nil
+}
+
+// waitForBindingOperationComplete will block until the cloudformation
+// stack referenced by name is in a success or failed state, the context is
+// canceled or the is an error returned from cloudformation
+func (s *Provider) waitForBindingOperationComplete(ctx context.Context, stackName string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ErrBindingDeadlineExeceeded
+		case <-time.After(PollingInterval):
+			lastOperation, err := s.lastBindingOperation(ctx, stackName, BindOperation)
+			if err != nil {
+				return err
+			}
+			switch lastOperation.State {
+			case domain.Succeeded:
+				return nil
+			case domain.Failed:
+				return fmt.Errorf("%s", lastOperation.Description)
+			default:
+				continue
+			}
+		}
+	}
 }
 
 func (s *Provider) Unbind(ctx context.Context, unbindData provideriface.UnbindData) (*domain.UnbindSpec, error) {
@@ -228,7 +295,7 @@ func (s *Provider) Unbind(ctx context.Context, unbindData provideriface.UnbindDa
 
 	return &domain.UnbindSpec{
 		OperationData: UnbindOperation,
-		IsAsync:       true,
+		IsAsync:       unbindData.AsyncAllowed,
 	}, nil
 }
 
@@ -296,9 +363,13 @@ func (s *Provider) LastOperation(ctx context.Context, lastOperationData provider
 
 func (s *Provider) LastBindingOperation(ctx context.Context, lastBindingOperationData provideriface.LastBindingOperationData) (*domain.LastOperation, error) {
 	stackName := s.getStackName(lastBindingOperationData.BindingID)
+	return s.lastBindingOperation(ctx, stackName, lastBindingOperationData.PollDetails.OperationData)
+}
+
+func (s *Provider) lastBindingOperation(ctx context.Context, stackName string, opData string) (*domain.LastOperation, error) {
 	stack, err := s.getStack(ctx, stackName)
 	if err == ErrStackNotFound {
-		if lastBindingOperationData.PollDetails.OperationData == UnbindOperation {
+		if opData == UnbindOperation {
 			return &domain.LastOperation{
 				State:       domain.Succeeded,
 				Description: "done",
@@ -334,6 +405,10 @@ func (s *Provider) LastBindingOperation(ctx context.Context, lastBindingOperatio
 
 func (s *Provider) GetBinding(ctx context.Context, getBindingData provideriface.GetBindData) (*domain.GetBindingSpec, error) {
 	userStackName := s.getStackName(getBindingData.BindingID)
+	return s.getBinding(ctx, userStackName)
+}
+
+func (s *Provider) getBinding(ctx context.Context, userStackName string) (*domain.GetBindingSpec, error) {
 	userStack, err := s.getStack(ctx, userStackName)
 	if err == ErrStackNotFound {
 		return nil, ErrStackNotFound
@@ -386,6 +461,23 @@ func (s *Provider) getStack(ctx context.Context, stackName string) (*cloudformat
 		return nil, fmt.Errorf("describeOutput contained a nil StackStatus, potential issue with AWS Client")
 	}
 	return state, nil
+}
+
+// tryDestroyStack removes the cloudformation stack by name. It does not use
+// the request's context to avoid the siutation where a timeout has been
+// reached and the stack needs to be cleaned up.
+// It is intended to be run as a one off goroutine at a point when no error can be returned
+// so can only log any problems.
+func (s *Provider) tryDestroyStack(stackName string) {
+	deleteCtx := context.Background()
+	deleteCtx, cancel := context.WithTimeout(deleteCtx, 60*time.Second)
+	defer cancel()
+	_, err := s.Client.DeleteStackWithContext(deleteCtx, &cloudformation.DeleteStackInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		s.Logger.Error("try-destroy-stack", err)
+	}
 }
 
 func (s *Provider) getStackName(instanceID string) string {

--- a/sqs/provider_test.go
+++ b/sqs/provider_test.go
@@ -657,8 +657,9 @@ var _ = Describe("Provider", func() {
 			)
 
 			unbindData := provideriface.UnbindData{
-				InstanceID: "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
-				BindingID:  "c6ea1339-7ade-4952-9247-e419b59e7b67",
+				InstanceID:   "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
+				BindingID:    "c6ea1339-7ade-4952-9247-e419b59e7b67",
+				AsyncAllowed: true,
 			}
 			_, err := sqsProvider.Unbind(context.Background(), unbindData)
 			Expect(err).NotTo(HaveOccurred())
@@ -674,8 +675,9 @@ var _ = Describe("Provider", func() {
 			}, nil)
 
 			unbindData := provideriface.UnbindData{
-				InstanceID: "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
-				BindingID:  "c6ea1339-7ade-4952-9247-e419b59e7b67",
+				InstanceID:   "09E1993E-62E2-4040-ADF2-4D3EC741EFE6",
+				BindingID:    "c6ea1339-7ade-4952-9247-e419b59e7b67",
+				AsyncAllowed: true,
 			}
 			spec, err := sqsProvider.Unbind(context.Background(), unbindData)
 			Expect(err).NotTo(HaveOccurred())
@@ -701,8 +703,9 @@ var _ = Describe("Provider", func() {
 
 		BeforeEach(func() {
 			bindData = provideriface.BindData{
-				InstanceID: "a5da1b66-da42-4c83-b806-f287bc589ab3",
-				BindingID:  "f56687df-e3d0-452a-9755-1a6d6d9e248f",
+				InstanceID:   "a5da1b66-da42-4c83-b806-f287bc589ab3",
+				BindingID:    "f56687df-e3d0-452a-9755-1a6d6d9e248f",
+				AsyncAllowed: true,
 			}
 			fakeCfnClient.DescribeStacksWithContextReturnsOnCall(0, &cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{

--- a/testing/fixtures/config.json
+++ b/testing/fixtures/config.json
@@ -4,6 +4,7 @@
   "log_level": "debug",
   "aws_region": "eu-west-2",
   "resource_prefix": "test-paas-sqs-broker",
+  "context_timeout_seconds": 300,
   "iam_ip_restriction_policy_arn": "__SET_IN_TEST__",
   "deploy_env": "testdev",
   "catalog": {

--- a/vendor/github.com/alphagov/paas-service-broker-base/broker/broker.go
+++ b/vendor/github.com/alphagov/paas-service-broker-base/broker/broker.go
@@ -25,7 +25,7 @@ var (
 
 var (
 	// DefaultContextTimeout is the default timeout in which broker requests
-	// (and therefore Provider implementations) should return within
+	// (and therefore Provider implementations) should return
 	DefaultContextTimeout = time.Second * 60
 )
 
@@ -99,7 +99,7 @@ func (b *Broker) Provision(
 		return domain.ProvisionedServiceSpec{}, err
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -157,7 +157,7 @@ func (b *Broker) Deprovision(
 		return domain.DeprovisionServiceSpec{}, brokerapi.ErrAsyncRequired
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	service, err := findServiceByID(b.config.Catalog, details.ServiceID)
@@ -221,7 +221,7 @@ func (b *Broker) Bind(
 		"details":     details,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -274,7 +274,7 @@ func (b *Broker) Unbind(
 		"details":     details,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -324,7 +324,7 @@ func (b *Broker) GetBinding(
 		"binding-id":  bindingID,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	data := provider.GetBindData{
@@ -382,7 +382,7 @@ func (b *Broker) Update(
 		return domain.UpdateServiceSpec{}, err
 	}
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lock, err := b.ObtainServiceLock(providerCtx, instanceID, locketMaxTTL)
@@ -429,7 +429,7 @@ func (b *Broker) LastOperation(
 		"poll-details": pollDetails,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lastOperationData := provider.LastOperationData{
@@ -469,7 +469,7 @@ func (b *Broker) LastBindingOperation(
 		"poll-details": pollDetails,
 	})
 
-	providerCtx, cancelFunc := context.WithTimeout(ctx, DefaultContextTimeout)
+	providerCtx, cancelFunc := context.WithTimeout(ctx, b.config.API.ContextTimeout())
 	defer cancelFunc()
 
 	lastOperationData := provider.LastBindingOperationData{

--- a/vendor/github.com/alphagov/paas-service-broker-base/broker/config.go
+++ b/vendor/github.com/alphagov/paas-service-broker-base/broker/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"reflect"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/pivotal-cf/brokerapi/domain"
@@ -89,12 +90,13 @@ func (c Config) Validate() error {
 }
 
 type API struct {
-	BasicAuthUsername string `json:"basic_auth_username"`
-	BasicAuthPassword string `json:"basic_auth_password"`
-	Port              string `json:"port"`
-	LogLevel          string `json:"log_level"`
-	LagerLogLevel     lager.LogLevel
-	Locket            *LocketConfig `json:"locket"`
+	BasicAuthUsername     string `json:"basic_auth_username"`
+	BasicAuthPassword     string `json:"basic_auth_password"`
+	Port                  string `json:"port"`
+	LogLevel              string `json:"log_level"`
+	LagerLogLevel         lager.LogLevel
+	Locket                *LocketConfig `json:"locket"`
+	ContextTimeoutSeconds int           `json:"context_timeout_seconds"`
 }
 
 func (api API) ConvertLogLevel() (lager.LogLevel, error) {
@@ -109,6 +111,13 @@ func (api API) ConvertLogLevel() (lager.LogLevel, error) {
 		return lager.DEBUG, fmt.Errorf("Config error: log level %s does not map to a Lager log level", api.LogLevel)
 	}
 	return logLevel, nil
+}
+
+func (api API) ContextTimeout() time.Duration {
+	if api.ContextTimeoutSeconds == 0 {
+		return DefaultContextTimeout
+	}
+	return time.Duration(api.ContextTimeoutSeconds) * time.Second
 }
 
 type Catalog struct {

--- a/vendor/github.com/alphagov/paas-service-broker-base/testing/broker_tester.go
+++ b/vendor/github.com/alphagov/paas-service-broker-base/testing/broker_tester.go
@@ -62,16 +62,18 @@ func (bt BrokerTester) Deprovision(instanceID, serviceID, planID string, async b
 	)
 }
 
-func (bt BrokerTester) Bind(instanceID, bindingID string, body RequestBody, asyncAllowed bool) *httptest.ResponseRecorder {
+func (bt BrokerTester) Bind(instanceID, bindingID string, body RequestBody, async bool) *httptest.ResponseRecorder {
 	bodyJSON, _ := json.Marshal(body)
 	return bt.Put(
 		fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s", instanceID, bindingID),
 		bytes.NewBuffer(bodyJSON),
-		url.Values{},
+		url.Values{
+			"accepts_incomplete": []string{strconv.FormatBool(async)},
+		},
 	)
 }
 
-func (bt BrokerTester) Unbind(instanceID, serviceID, planID, bindingID string, asyncAllowed bool) *httptest.ResponseRecorder {
+func (bt BrokerTester) Unbind(instanceID, serviceID, planID, bindingID string, async bool) *httptest.ResponseRecorder {
 	return bt.Delete(
 		fmt.Sprintf(
 			"/v2/service_instances/%s/service_bindings/%s",
@@ -80,8 +82,9 @@ func (bt BrokerTester) Unbind(instanceID, serviceID, planID, bindingID string, a
 		),
 		nil,
 		url.Values{
-			"service_id": []string{serviceID},
-			"plan_id":    []string{planID},
+			"service_id":         []string{serviceID},
+			"plan_id":            []string{planID},
+			"accepts_incomplete": []string{strconv.FormatBool(async)},
 		},
 	)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ code.cloudfoundry.org/locket/models
 code.cloudfoundry.org/rfc5424
 # code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
 code.cloudfoundry.org/tlsconfig
-# github.com/alphagov/paas-service-broker-base v0.9.0
+# github.com/alphagov/paas-service-broker-base v0.10.0
 ## explicit
 github.com/alphagov/paas-service-broker-base/broker
 github.com/alphagov/paas-service-broker-base/provider

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ code.cloudfoundry.org/locket/models
 code.cloudfoundry.org/rfc5424
 # code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
 code.cloudfoundry.org/tlsconfig
-# github.com/alphagov/paas-service-broker-base v0.8.0
+# github.com/alphagov/paas-service-broker-base v0.9.0
 ## explicit
 github.com/alphagov/paas-service-broker-base/broker
 github.com/alphagov/paas-service-broker-base/provider
@@ -455,4 +455,5 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
### What

Adds support for clients that are unable to process the async binding flow.

We discovered that cloudcontroller does not handle async binding requests when creating service keys. This was leading to errors on `cf create-service-key` and leaving stacks orphened in AWS.

This adds an alternative synchronous binding path (based on holding the request and periodically polling for the stack status) for clients that do not support async.

it takes the binding stack ~1m to complete ... which I believe is probably just about acceptable for the binding request to hang for (but obviously not ideal).

The change required fixing the broker-base's brokertester package which was incorrectly reporting the client's "AsyncAllowed" parameter, so there is a broker-base bump.

https://trello.com/c/Ko4arivr/989-get-the-rough-pass-of-the-deployment-with-pipelines-on-to-paas