### PR TITLE
[#177115112] Assign a cost allocation tag to queues and IAM users

### DIFF
--- a/sqs/provider.go
+++ b/sqs/provider.go
@@ -40,6 +40,14 @@ var (
 	UnbindOperation      = "unbind"
 )
 
+const (
+	TagCostAllocation = "chargeable_entity"
+	TagEnvironment    = "Environment"
+	TagName           = "Name"
+	TagService        = "Service"
+	TagServiceId      = "ServiceID"
+)
+
 type Provider struct {
 	Environment          string // Name of environment to tag resources with
 	Client               Client // AWS SDK compatible client
@@ -53,11 +61,13 @@ type Provider struct {
 func (s *Provider) Provision(ctx context.Context, provisionData provideriface.ProvisionData) (*domain.ProvisionedServiceSpec, error) {
 	queueTemplate := QueueTemplateBuilder{}
 	queueTemplate.QueueName = s.getStackName(provisionData.InstanceID)
+
 	queueTemplate.Tags = map[string]string{
-		"Name":        provisionData.InstanceID,
-		"Service":     "sqs",
-		"ServiceID":   provisionData.Details.ServiceID,
-		"Environment": s.Environment,
+		TagName:           provisionData.InstanceID,
+		TagService:        "sqs",
+		TagServiceId:      provisionData.Details.ServiceID,
+		TagEnvironment:    s.Environment,
+		TagCostAllocation: provisionData.InstanceID,
 	}
 	if provisionData.Plan.Name == "fifo" {
 		queueTemplate.FIFOQueue = true
@@ -152,10 +162,11 @@ func (s *Provider) Bind(ctx context.Context, bindData provideriface.BindData) (*
 		AdditionalUserPolicy: s.AdditionalUserPolicy,
 		PermissionsBoundary:  s.PermissionsBoundary,
 		Tags: map[string]string{
-			"Name":        bindData.BindingID,
-			"Service":     "sqs",
-			"ServiceID":   bindData.Details.ServiceID,
-			"Environment": s.Environment,
+			TagName:           bindData.BindingID,
+			TagService:        "sqs",
+			TagServiceId:      bindData.Details.ServiceID,
+			TagEnvironment:    s.Environment,
+			TagCostAllocation: bindData.InstanceID,
 		},
 		PrimaryQueueARN:   getStackOutput(queueStack, OutputPrimaryQueueARN),
 		PrimaryQueueURL:   getStackOutput(queueStack, OutputPrimaryQueueURL),

--- a/sqs/provider_test.go
+++ b/sqs/provider_test.go
@@ -274,21 +274,30 @@ var _ = Describe("Provider", func() {
 			It("Should set appropriate tags", func() {
 				Expect(queue.Tags).To(And(
 					ContainElement(goformationtags.Tag{
-						Key:   "Name",
+						Key:   sqs.TagName,
 						Value: provisionData.InstanceID,
 					}),
 					ContainElement(goformationtags.Tag{
-						Key:   "Service",
+						Key:   sqs.TagService,
 						Value: "sqs",
 					}),
 					ContainElement(goformationtags.Tag{
-						Key:   "ServiceID",
+						Key:   sqs.TagServiceId,
 						Value: provisionData.Details.ServiceID,
 					}),
 					ContainElement(goformationtags.Tag{
-						Key:   "Environment",
+						Key:   sqs.TagEnvironment,
 						Value: "test",
 					}),
+				))
+			})
+
+			It("Should set a cost allocation tag", func() {
+				Expect(queue.Tags).To(ContainElement(
+					goformationtags.Tag{
+						Key:   sqs.TagCostAllocation,
+						Value: provisionData.InstanceID,
+					},
 				))
 			})
 
@@ -768,18 +777,26 @@ var _ = Describe("Provider", func() {
 			It("Should set appropriate tags", func() {
 				Expect(user.Tags).To(And(
 					ContainElement(goformationtags.Tag{
-						Key:   "Name",
+						Key:   sqs.TagName,
 						Value: bindData.BindingID,
 					}),
 					ContainElement(goformationtags.Tag{
-						Key:   "Service",
+						Key:   sqs.TagService,
 						Value: "sqs",
 					}),
 					ContainElement(goformationtags.Tag{
-						Key:   "Environment",
+						Key:   sqs.TagEnvironment,
 						Value: "test",
 					}),
 				))
+			})
+
+			It("Should set a cost allocation tag", func() {
+				Expect(user.Tags).To(ContainElement(
+					goformationtags.Tag{
+						Key:   sqs.TagCostAllocation,
+						Value: bindData.InstanceID,
+					}))
 			})
 
 			It("should use create user name with binding id", func() {


### PR DESCRIPTION
What
---

Assigns a cost allocation tag to queues and IAM users so that we can track how much each service instance and its bindings is costing us.

Refactor the tag names to constants while we're in there, to make them easier to change/add to in the future.

How to review
---
Check that I got the tag name right