### PR TITLE
Add makefile option to bosh scp built binary to an existing bosh environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea
 paas-sqs-broker
 local.nix
+
+# Temporary Build Files
+amd64/*

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,12 @@ test:
 .PHONY: generate
 generate:
 	go generate ./...
+
+.PHONY: build_amd64
+build_amd64:
+	mkdir -p amd64
+	GOOS=linux GOARCH=amd64 go build -o amd64/sqs-broker
+
+.PHONY: bosh_scp
+bosh_scp: build_amd64
+	./scripts/bosh-scp.sh

--- a/README.md
+++ b/README.md
@@ -173,3 +173,13 @@ fly -t paas-ci execute -c ci/integration.yml --input repo=.
 ```
 
 (this will upload your current modifications to concourse and execute the integration tests).
+
+## Patching an existing bosh environment
+
+If you want to patch an existing bosh environment you can run the following command:
+
+```
+make bosh_scp
+```
+
+This requires an existing bosh session to be established beforehand.

--- a/scripts/bosh-scp.sh
+++ b/scripts/bosh-scp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+function run_command() {
+    local command=$1
+    local message=$2
+
+    echo -n "${message}... "
+
+    if ! output=$(bash -c "${command}" 2>&1); then
+        echo -e "failed.\n\n"
+        echo "Command Failed: ${command}"
+        echo ""
+        echo "Output: ${output}"
+        exit 1
+    fi
+    echo "done."
+}
+
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+command -v bosh >/dev/null 2>&1 || { echo >&2 "bosh is required but it's not installed.  Aborting."; exit 1; }
+command -v cut >/dev/null 2>&1 || { echo >&2 "cut is required but it's not installed.  Aborting."; exit 1; }
+
+bosh vms --json | jq -r '.Tables[0].Rows[] | select(.instance|startswith("sqs_broker/")) | .instance' | while read -r instance; do
+    run_command "bosh ssh ${instance} sudo monit stop sqs-broker" "stopping sqs-broker on ${instance}"
+    run_command "bosh scp ./amd64/sqs-broker ${instance}:/tmp/sqs-broker" "copying sqs-broker binary to tmp on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/sqs-broker /var/vcap/packages/sqs-broker/bin/paas-sqs-broker" "moving sqs-broker binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start sqs-broker" "starting sqs-broker on ${instance}"
+done


### PR DESCRIPTION
What
----

Add a make bosh_scp target for building and deploying into an existing environment.

Why
----

This allows a more rapid way to deploy and test your changes in an existing environment

How to review
-------------

Test it

---