### PR TITLE
golang: 1.18 -> 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.18
+        go-version: "1.20"
       id: go
 
     - name: Check out code into the Go module directory

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.18.2-stretch
+    tag: "1.20"
 inputs:
   - name: repo
 run:

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,4 @@ require (
 	google.golang.org/protobuf v1.26.0 // indirect
 )
 
-go 1.18
+go 1.20


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184967033

Not bumping dependencies as that can balloon in scope and we don't have time for that right now.