### PR TITLE
Update to go 1.22

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 jobs:
 
   build:

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.21"
+    tag: "1.22"
 inputs:
   - name: repo
 run:

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,4 @@ require (
 	google.golang.org/protobuf v1.26.0 // indirect
 )
 
-go 1.21
+go 1.22


### PR DESCRIPTION
## What

Use go v1.22

## Why

To keep up to date when upgrading go buildpack

## How to review

Ensure that this broker deploys okay to a dev environment and passes tests

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨